### PR TITLE
loosen content-type parsing for decode_content (json/application*)

### DIFF
--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -149,7 +149,7 @@ def make_decimal_timedelta_converter(**kwargs) -> Converter:
 def _decode_content(response: CachedResponse, response_dict: Dict) -> Dict:
     """Decode response body into a human-readable format, if possible"""
     # Decode body as JSON
-    if response.headers.get('Content-Type').startswith('application/json'):
+    if response.headers.get('Content-Type').startswith('application/json', 'application/ld+json', 'application/vnd.api+json'):
         try:
             response_dict['_decoded_content'] = response.json()
             response_dict.pop('_content', None)

--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -43,7 +43,7 @@ class CattrStage(Stage):
 
     * Response body will be decoded into a human-readable format (if possible) during serialization,
       and re-encoded during deserialization to reconstruct the original response.
-    * Supported  Content-Types are ``application/json`` and ``text/*``. All other types will be saved as-is.
+    * Supported  Content-Types are ``application/json*`` and ``text/*``. All other types will be saved as-is.
     * Decoded responses are saved in a separate ``_decoded_content`` attribute, to ensure that
       ``_content`` is always binary.
     * This is the default behavior for Filesystem, DynamoDB, and MongoDB backends.
@@ -149,7 +149,7 @@ def make_decimal_timedelta_converter(**kwargs) -> Converter:
 def _decode_content(response: CachedResponse, response_dict: Dict) -> Dict:
     """Decode response body into a human-readable format, if possible"""
     # Decode body as JSON
-    if response.headers.get('Content-Type') == 'application/json':
+    if response.headers.get('Content-Type').startswith('application/json'):
         try:
             response_dict['_decoded_content'] = response.json()
             response_dict.pop('_content', None)


### PR DESCRIPTION
This loosens content-type parsing for decode_content logic, so that it supports headers like `application/json;charset=UTF-8`.

If you accept the principle, I will add a test case and update the changelog (hence just draft so far).

Note that I just listed some common json mime types, but there's probably more than that out there. I didn't find a dependency-free way to determine if it's a json subtype, but arguably we could even loosed up more (e.g. startswith `application/` and contains `json`), as worst case decoding fail and is ignored.

Closes (no issue)

### Checklist
- [x] Added docstrings and type annotations
- [ ] Added test coverage
- [ ] Updated changelog to describe any user-facing features or changed behavior
